### PR TITLE
Quality pass: formatting, provider pinning, deprecation fixes, and docs

### DIFF
--- a/Modules/Aws_Module/network.tf
+++ b/Modules/Aws_Module/network.tf
@@ -85,7 +85,7 @@ resource "aws_network_interface" "web-server-nic" {
 
 resource "aws_eip" "one" {
   instance                  = aws_instance.web-server-instance.id
-  vpc                       = true
+  domain                    = "vpc"
   network_interface         = aws_network_interface.web-server-nic.id
   associate_with_private_ip = var.server_private_ip
   depends_on                = [aws_internet_gateway.gw]

--- a/Modules/Aws_Module/output.tf
+++ b/Modules/Aws_Module/output.tf
@@ -1,3 +1,4 @@
 output "server_public_ip" {
-  value = aws_eip.one.public_ip
+  description = "Public Elastic IP attached to the AWS EC2 instance."
+  value       = aws_eip.one.public_ip
 }

--- a/Modules/Aws_Module/variables.tf
+++ b/Modules/Aws_Module/variables.tf
@@ -3,37 +3,55 @@
 # }
 
 variable "cidr_block_ip" {
-  default = "11.0.0.0/16"
+  description = "CIDR block for the AWS VPC."
+  type        = string
+  default     = "11.0.0.0/16"
 }
 
 variable "tag" {
-  default = "aws_1"
+  description = "Name tag applied to the VPC, route table and subnet."
+  type        = string
+  default     = "aws_1"
 }
 
 variable "all_ips" {
-  default = "0.0.0.0/0"
+  description = "CIDR used for the default route and the allow-all security group rules."
+  type        = string
+  default     = "0.0.0.0/0"
 }
 
 variable "subnet_ip" {
-  default = "11.0.1.0/24"
+  description = "CIDR block for the public subnet."
+  type        = string
+  default     = "11.0.1.0/24"
 }
 
 variable "zone" {
-  default = "us-east-1a"
+  description = "AWS availability zone for the subnet and EC2 instance."
+  type        = string
+  default     = "us-east-1a"
 }
 
 variable "server_private_ip" {
-  default = "11.0.1.50"
+  description = "Static private IP assigned to the EC2 instance network interface."
+  type        = string
+  default     = "11.0.1.50"
 }
 
 variable "ec2_ami" {
-  default = "ami-053b0d53c279acc90"
+  description = "AMI ID used for the EC2 instance."
+  type        = string
+  default     = "ami-053b0d53c279acc90"
 }
 
 variable "instance_type" {
-  default = "t2.micro"
+  description = "EC2 instance type."
+  type        = string
+  default     = "t2.micro"
 }
 
 variable "key_name" {
-  default = "main.key"
+  description = "Name of the EC2 key pair used for SSH access."
+  type        = string
+  default     = "main.key"
 }

--- a/Modules/Azure_Module/compute/compute.tf
+++ b/Modules/Azure_Module/compute/compute.tf
@@ -31,8 +31,8 @@ resource "azurerm_linux_virtual_machine" "main" {
   resource_group_name   = var.rgname
   size                  = var.vm_size
   eviction_policy       = var.eviction_policy
-  priority              = var.priority   // comment this to provision regular VM
-  max_bid_price         = var.max_bid_price  // comment this to provision regular VM
+  priority              = var.priority      // comment this to provision regular VM
+  max_bid_price         = var.max_bid_price // comment this to provision regular VM
   network_interface_ids = [azurerm_network_interface.azurenic.id]
   user_data             = base64encode(data.template_file.cloud-config.rendered)
 
@@ -55,5 +55,11 @@ resource "azurerm_linux_virtual_machine" "main" {
   admin_ssh_key {
     username   = var.username
     public_key = file(var.ssh_key)
+  }
+
+  tags = {
+    Project   = "terraform-multicloud-infra"
+    ManagedBy = "Terraform"
+    Hostname  = var.hostname
   }
 }

--- a/Modules/Azure_Module/compute/compute.tf
+++ b/Modules/Azure_Module/compute/compute.tf
@@ -1,5 +1,5 @@
-data "template_file" "cloud-config" {
-  template = <<YAML
+locals {
+  cloud_config = <<YAML
 #cloud-config
 
 # Add a shell script file
@@ -34,7 +34,7 @@ resource "azurerm_linux_virtual_machine" "main" {
   priority              = var.priority      // comment this to provision regular VM
   max_bid_price         = var.max_bid_price // comment this to provision regular VM
   network_interface_ids = [azurerm_network_interface.azurenic.id]
-  user_data             = base64encode(data.template_file.cloud-config.rendered)
+  user_data             = base64encode(local.cloud_config)
 
   source_image_reference {
     offer     = local.source_image_reference.offer

--- a/Modules/Azure_Module/compute/output.tf
+++ b/Modules/Azure_Module/compute/output.tf
@@ -1,4 +1,5 @@
 output "server_details" {
+  description = "Per-VM facts (name, role booleans and private IP) consumed by the inventory and load balancer modules."
   value = {
     name                 = join("", [azurerm_linux_virtual_machine.main.computer_name])
     all_details          = join("", [azurerm_linux_virtual_machine.main.computer_name, " ansible_host=", azurerm_linux_virtual_machine.main.private_ip_address, " ansible_user=ubuntu"])
@@ -11,6 +12,7 @@ output "server_details" {
 }
 
 output "backenddetails" {
+  description = "Minimal IP/name pair used to register the VM in the Azure load balancer backend pools."
   value = {
     ip_address  = azurerm_linux_virtual_machine.main.private_ip_address
     server_name = azurerm_linux_virtual_machine.main.computer_name
@@ -18,6 +20,7 @@ output "backenddetails" {
 }
 
 output "output_ips" {
+  description = "VM name and private IP surfaced at the root for quick reference."
   value = {
     server_ip   = azurerm_linux_virtual_machine.main.private_ip_address
     server_name = azurerm_linux_virtual_machine.main.computer_name

--- a/Modules/Azure_Module/compute/variables.tf
+++ b/Modules/Azure_Module/compute/variables.tf
@@ -1,13 +1,19 @@
 variable "vm_size" {
-  default = "Standard_B1s"
+  description = "Azure VM SKU/size for the instance."
+  type        = string
+  default     = "Standard_B1s"
 }
 
 variable "username" {
-  default = "ubuntu"
+  description = "Admin username configured on the VM (also used as the SSH user)."
+  type        = string
+  default     = "ubuntu"
 }
 
 variable "hostname" {
-  default = "server"
+  description = "Hostname / computer name of the VM; also drives the NIC and disk names."
+  type        = string
+  default     = "server"
 }
 
 locals {
@@ -17,7 +23,13 @@ locals {
     version   = "latest"
   }
 }
+
 variable "os_disk" {
+  description = "OS disk configuration (name suffix and caching mode)."
+  type = object({
+    name    = string
+    caching = string
+  })
   default = {
     name    = "osdisk"
     caching = "ReadWrite"
@@ -25,44 +37,61 @@ variable "os_disk" {
 }
 
 variable "diskstoragetype" {
-  default = "Standard_LRS"
+  description = "Managed disk storage account type for the OS disk (e.g. Standard_LRS, Premium_LRS)."
+  type        = string
+  default     = "Standard_LRS"
 }
 
 variable "diskstoragegbs" {
-  default = "32"
+  description = "OS disk size in GB."
+  type        = number
+  default     = 32
 }
 
 variable "eviction_policy" {
-  default = "Delete"
+  description = "Eviction policy for Spot VMs (Delete or Deallocate)."
+  type        = string
+  default     = "Delete"
 }
+
 variable "priority" {
-  default = "Spot"
+  description = "VM priority. Set to Spot for spot instances; comment the priority/max_bid_price lines for a regular VM."
+  type        = string
+  default     = "Spot"
 }
+
 variable "max_bid_price" {
-  default = "0.011"
+  description = "Maximum hourly price (USD) for a Spot VM; -1 means pay up to the on-demand price."
+  type        = number
+  default     = 0.011
 }
 
 variable "location" {
-
+  description = "Azure region where the VM is deployed."
+  type        = string
 }
 
 variable "rgname" {
-
+  description = "Name of the Azure resource group that hosts the VM."
+  type        = string
 }
 
 variable "subnet_id" {
-
+  description = "ID of the subnet the VM's NIC is attached to."
+  type        = string
 }
 
 variable "imagetype" {
-
+  description = "Image SKU (e.g. 22_04-lts-arm64) used for the source image reference."
+  type        = string
 }
 
 variable "ssh_key" {
-
+  description = "Path to the SSH public key file authorised on the VM."
+  type        = string
 }
 
 variable "imagename" {
-
+  description = "Ubuntu image codename used to build the marketplace offer (e.g. jammy)."
+  type        = string
 }
-

--- a/Modules/Azure_Module/k8sloadbalancer/output.tf
+++ b/Modules/Azure_Module/k8sloadbalancer/output.tf
@@ -1,3 +1,4 @@
 output "private_ip" {
-  value = azurerm_lb.k8slb.private_ip_address
+  description = "Private frontend IP of the internal Kubernetes API load balancer (port 6443)."
+  value       = azurerm_lb.k8slb.private_ip_address
 }

--- a/Modules/Azure_Module/k8sloadbalancer/variables.tf
+++ b/Modules/Azure_Module/k8sloadbalancer/variables.tf
@@ -1,21 +1,26 @@
 variable "rgname" {
-
+  description = "Name of the Azure resource group that hosts the internal load balancer."
+  type        = string
 }
 
 variable "subnet_id" {
-
+  description = "ID of the subnet for the load balancer's private frontend IP."
+  type        = string
 }
 
 variable "location" {
-
+  description = "Azure region for the load balancer."
+  type        = string
 }
 
 variable "azureservers" {
-
+  description = "Map of Azure compute module instances; master nodes are selected as backend pool members."
+  type        = any
 }
 
 variable "azurevnetid" {
-
+  description = "ID of the virtual network used when registering backend pool addresses."
+  type        = string
 }
 
 locals {

--- a/Modules/Azure_Module/network/network.tf
+++ b/Modules/Azure_Module/network/network.tf
@@ -1,6 +1,10 @@
 resource "azurerm_resource_group" "azurerg" {
   name     = "rg"
   location = var.region
+  tags = {
+    Project   = "terraform-multicloud-infra"
+    ManagedBy = "Terraform"
+  }
 }
 
 # virtual network
@@ -9,6 +13,10 @@ resource "azurerm_virtual_network" "azurevcn" {
   address_space       = [var.cidr_ip_block]
   location            = azurerm_resource_group.azurerg.location
   resource_group_name = azurerm_resource_group.azurerg.name
+  tags = {
+    Project   = "terraform-multicloud-infra"
+    ManagedBy = "Terraform"
+  }
 }
 
 # private subnet

--- a/Modules/Azure_Module/network/outputs.tf
+++ b/Modules/Azure_Module/network/outputs.tf
@@ -1,19 +1,24 @@
 output "location" {
-  value = azurerm_resource_group.azurerg.location
+  description = "Azure region of the resource group."
+  value       = azurerm_resource_group.azurerg.location
 }
 
 output "name" {
-  value = azurerm_resource_group.azurerg.name
+  description = "Name of the Azure resource group."
+  value       = azurerm_resource_group.azurerg.name
 }
 
 output "azureprivatesubnet_id" {
-  value = azurerm_subnet.privatesubnet.id
+  description = "ID of the private subnet that hosts the workload VMs."
+  value       = azurerm_subnet.privatesubnet.id
 }
 
 output "vcnname" {
-  value = azurerm_virtual_network.azurevcn.name
+  description = "Name of the Azure virtual network."
+  value       = azurerm_virtual_network.azurevcn.name
 }
 
 output "azurevnet_id" {
-  value = azurerm_virtual_network.azurevcn.id
+  description = "ID of the Azure virtual network."
+  value       = azurerm_virtual_network.azurevcn.id
 }

--- a/Modules/Azure_Module/network/variables.tf
+++ b/Modules/Azure_Module/network/variables.tf
@@ -1,11 +1,17 @@
 variable "region" {
-  default = "westus3"
+  description = "Azure region for the resource group and all networking resources."
+  type        = string
+  default     = "westus3"
 }
 
 variable "cidr_ip_block" {
-  default = "192.0.0.0/16"
+  description = "Address space (CIDR) for the Azure virtual network."
+  type        = string
+  default     = "192.0.0.0/16"
 }
 
 variable "privatesubnetip" {
-  default = "192.0.1.0/24"
+  description = "CIDR block for the private subnet that hosts the workload VMs."
+  type        = string
+  default     = "192.0.1.0/24"
 }

--- a/Modules/Azure_Module/publicloadbalancer/lb.tf
+++ b/Modules/Azure_Module/publicloadbalancer/lb.tf
@@ -10,7 +10,7 @@ resource "azurerm_public_ip" "publiclbip" {
   resource_group_name = var.rgname
   location            = var.location
   allocation_method   = "Static"
-  sku                = "Standard"
+  sku                 = "Standard"
 }
 
 
@@ -20,9 +20,9 @@ resource "azurerm_application_gateway" "publiclbgw" {
   location            = var.location
 
   sku {
-    name           = "Standard_v2"
-    tier           = "Standard_v2"
-    capacity       = 1
+    name     = "Standard_v2"
+    tier     = "Standard_v2"
+    capacity = 1
   }
 
   ssl_certificate {
@@ -48,7 +48,7 @@ resource "azurerm_application_gateway" "publiclbgw" {
   }
 
   backend_address_pool {
-    name = local.backend_address_pool_name
+    name         = local.backend_address_pool_name
     ip_addresses = local.instances
   }
 
@@ -65,12 +65,12 @@ resource "azurerm_application_gateway" "publiclbgw" {
     frontend_ip_configuration_name = local.frontend_ip_configuration_name
     frontend_port_name             = local.frontend_port_name
     protocol                       = "Https"
-    ssl_certificate_name = "certificate"
+    ssl_certificate_name           = "certificate"
   }
 
   request_routing_rule {
     name                       = local.request_routing_rule_name
-    priority = 9
+    priority                   = 9
     rule_type                  = "Basic"
     http_listener_name         = local.listener_name
     backend_address_pool_name  = local.backend_address_pool_name

--- a/Modules/Azure_Module/publicloadbalancer/output.tf
+++ b/Modules/Azure_Module/publicloadbalancer/output.tf
@@ -1,3 +1,4 @@
 output "public_ip" {
-  value = azurerm_public_ip.publiclbip.ip_address
+  description = "Public IP of the Azure Application Gateway fronting the worker NodePort (HTTPS 443)."
+  value       = azurerm_public_ip.publiclbip.ip_address
 }

--- a/Modules/Azure_Module/publicloadbalancer/variables.tf
+++ b/Modules/Azure_Module/publicloadbalancer/variables.tf
@@ -1,13 +1,16 @@
 variable "vcnname" {
-
+  description = "Name of the Azure virtual network the Application Gateway subnet is created in."
+  type        = string
 }
 
 variable "rgname" {
-
+  description = "Name of the Azure resource group that hosts the Application Gateway."
+  type        = string
 }
 
 variable "location" {
-
+  description = "Azure region for the Application Gateway."
+  type        = string
 }
 
 locals {
@@ -20,16 +23,16 @@ locals {
   redirect_configuration_name    = "azureapplicationgw-rdrcfg"
 }
 
-
-
 variable "azureservers" {
-
+  description = "Map of Azure compute module instances; worker nodes are selected as Application Gateway backend targets."
+  type        = any
 }
 
 variable "ssl_password" {
-  
+  description = "Password for the PFX SSL certificate (~/ssl/cert.pfx) bound to the Application Gateway HTTPS listener."
+  type        = string
+  sensitive   = true
 }
-
 
 locals {
   instances = [for instance in var.azureservers : instance.backenddetails.ip_address if length(regexall("worker", instance.backenddetails.server_name)) > 0 ? true : false]

--- a/Modules/Backend_Module/s3.tf
+++ b/Modules/Backend_Module/s3.tf
@@ -1,13 +1,19 @@
 resource "aws_s3_bucket" "s3_bucket" {
   bucket = var.bucket_name
-  versioning {
-    enabled = true
+}
+
+resource "aws_s3_bucket_versioning" "s3_bucket" {
+  bucket = aws_s3_bucket.s3_bucket.id
+  versioning_configuration {
+    status = "Enabled"
   }
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "s3_bucket" {
+  bucket = aws_s3_bucket.s3_bucket.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
   }
 }

--- a/Modules/Backend_Module/variables.tf
+++ b/Modules/Backend_Module/variables.tf
@@ -1,6 +1,11 @@
 variable "dynamodb_name" {
-  default = "statelockdb"
+  description = "Name of the DynamoDB table used for Terraform state locking."
+  type        = string
+  default     = "statelockdb"
 }
+
 variable "bucket_name" {
-  default = "statebucket"
+  description = "Name of the S3 bucket used to store the remote Terraform state."
+  type        = string
+  default     = "statebucket"
 }

--- a/Modules/Inventory_Module/provider.tf
+++ b/Modules/Inventory_Module/provider.tf
@@ -1,9 +1,9 @@
 terraform {
   required_version = ">= 0.15"
   required_providers {
-    oci = {
-      source  = "oracle/oci"
-      version = "5.19.0"
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 2.0"
     }
   }
 }

--- a/Modules/Inventory_Module/variables.tf
+++ b/Modules/Inventory_Module/variables.tf
@@ -1,43 +1,57 @@
-
 variable "oracleservers" {
-
+  description = "Map of OCI compute module instances (used to build the Ansible inventory groups)."
+  type        = any
 }
 
 variable "azureservers" {
-
+  description = "Map of Azure compute module instances (used to build the Ansible inventory groups)."
+  type        = any
 }
 
 variable "oraclek8stemplatepath" {
-
+  description = "Path to the templatefile used to render the Oracle Kubernetes Ansible inventory."
+  type        = string
 }
-variable "oraclek8sinventorypath" {
 
+variable "oraclek8sinventorypath" {
+  description = "Output path for the rendered Oracle Kubernetes Ansible inventory."
+  type        = string
 }
 
 variable "azurek8stemplatepath" {
-
+  description = "Path to the templatefile used to render the Azure Kubernetes Ansible inventory."
+  type        = string
 }
+
 variable "azurek8sinventorypath" {
-
+  description = "Output path for the rendered Azure Kubernetes Ansible inventory."
+  type        = string
 }
+
 variable "dbtemplatepath" {
-
+  description = "Path to the templatefile used to render the Galera/MariaDB Ansible inventory."
+  type        = string
 }
-variable "dbinventorypath" {
 
+variable "dbinventorypath" {
+  description = "Output path for the rendered Galera/MariaDB Ansible inventory."
+  type        = string
 }
 
 variable "controllerinventorypath" {
-
+  description = "Output path for the rendered Ansible controller inventory."
+  type        = string
 }
-variable "controllertemplatepath" {
 
+variable "controllertemplatepath" {
+  description = "Path to the templatefile used to render the Ansible controller inventory."
+  type        = string
 }
 
 locals {
   allservers = {
     ociservers      = [for server in var.oracleservers : server.server_details],
-    ocibastionpubip =  [for server in var.oracleservers : server.server_details.public_ip if server.server_details.is_oracle_bastion == true] == [] ? ["127.0.0.1"] : [for server in var.oracleservers : server.server_details.public_ip if server.server_details.is_oracle_bastion == true],
+    ocibastionpubip = [for server in var.oracleservers : server.server_details.public_ip if server.server_details.is_oracle_bastion == true] == [] ? ["127.0.0.1"] : [for server in var.oracleservers : server.server_details.public_ip if server.server_details.is_oracle_bastion == true],
     azservers       = [for server in var.azureservers : server.server_details]
     oracleips       = [for server in var.oracleservers : server.server_details.private_ip if server.server_details.is_oracle_bastion == false]
     azureips        = [for server in var.azureservers : server.server_details.private_ip]

--- a/Modules/Oracle_Module/compute/compute.tf
+++ b/Modules/Oracle_Module/compute/compute.tf
@@ -53,5 +53,10 @@ resource "oci_core_instance" "server" {
     user_data           = "${base64encode(data.template_file.cloud-config.rendered)}"
   }
 
+  freeform_tags = {
+    Project   = "terraform-multicloud-infra"
+    ManagedBy = "Terraform"
+  }
+
 }
 

--- a/Modules/Oracle_Module/compute/compute.tf
+++ b/Modules/Oracle_Module/compute/compute.tf
@@ -1,5 +1,5 @@
-data "template_file" "cloud-config" {
-  template = <<YAML
+locals {
+  cloud_config = <<YAML
 #cloud-config
 
 # Add a shell script file
@@ -50,7 +50,7 @@ resource "oci_core_instance" "server" {
 
   metadata = {
     ssh_authorized_keys = file(var.ssh_key)
-    user_data           = "${base64encode(data.template_file.cloud-config.rendered)}"
+    user_data           = base64encode(local.cloud_config)
   }
 
   freeform_tags = {

--- a/Modules/Oracle_Module/compute/outputs.tf
+++ b/Modules/Oracle_Module/compute/outputs.tf
@@ -1,4 +1,5 @@
 output "server_details" {
+  description = "Per-instance facts (name, role booleans, public/private IP) consumed by the inventory and load balancer modules."
   value = {
     name                  = join("", [oci_core_instance.server.display_name])
     all_details           = join("", [oci_core_instance.server.display_name, " ansible_host=", oci_core_instance.server.public_ip == "" ? oci_core_instance.server.private_ip : oci_core_instance.server.public_ip, " ansible_user=ubuntu"])
@@ -14,6 +15,7 @@ output "server_details" {
 
 
 output "backenddetails" {
+  description = "IP/ID/name tuple used to register the instance in the OCI load balancer backend sets."
   value = {
     server_ip   = oci_core_instance.server.private_ip
     server_id   = oci_core_instance.server.id
@@ -22,6 +24,7 @@ output "backenddetails" {
 }
 
 output "output_ips" {
+  description = "Instance name and its reachable (public if present, else private) IP surfaced at the root."
   value = {
     server_ip   = oci_core_instance.server.public_ip != "" ? oci_core_instance.server.public_ip : oci_core_instance.server.private_ip
     server_name = oci_core_instance.server.display_name

--- a/Modules/Oracle_Module/compute/variables.tf
+++ b/Modules/Oracle_Module/compute/variables.tf
@@ -1,36 +1,58 @@
-
 #Compute Variables
 
 variable "vm_shape" {
-  default = "VM.Standard.A1.Flex"
+  description = "OCI compute shape (defaults to the Ampere A1 Flex ARM shape)."
+  type        = string
+  default     = "VM.Standard.A1.Flex"
 }
 
 variable "assign_public_ip" {
-  default = "false"
+  description = "Whether the instance VNIC should receive a public IP (true for bastion/jenkins/argocd, false for private nodes)."
+  type        = bool
+  default     = false
 }
+
 variable "boot_volume" {
+  description = "Boot volume size in GB."
+  type        = number
 }
 
 variable "cpu" {
+  description = "Number of OCPUs allocated to the flexible shape."
+  type        = number
 }
 
 variable "memory" {
+  description = "Memory in GB allocated to the flexible shape."
+  type        = number
 }
 
 variable "server_name" {
+  description = "Display name and hostname label of the instance; drives the master/worker/db/bastion role."
+  type        = string
 }
 
 variable "ssh_key" {
+  description = "Path to the SSH public key file authorised on the instance."
+  type        = string
 }
 
 variable "AD" {
+  description = "OCI availability domain in which the instance is launched."
+  type        = string
 }
 
 variable "compartment_id" {
+  description = "OCID of the compartment that owns the instance."
+  type        = string
 }
 
 variable "subnet_id" {
+  description = "OCID of the subnet the instance VNIC is attached to."
+  type        = string
 }
 
 variable "image_id" {
+  description = "OCID of the boot image for the instance."
+  type        = string
 }

--- a/Modules/Oracle_Module/k8sloadbalancer/outputs.tf
+++ b/Modules/Oracle_Module/k8sloadbalancer/outputs.tf
@@ -1,4 +1,4 @@
 output "private_ip" {
-  value = oci_network_load_balancer_network_load_balancer.k8s_load_balancer.ip_addresses[0].ip_address
+  description = "Private IP of the internal Kubernetes API network load balancer (port 6443)."
+  value       = oci_network_load_balancer_network_load_balancer.k8s_load_balancer.ip_addresses[0].ip_address
 }
-

--- a/Modules/Oracle_Module/k8sloadbalancer/variables.tf
+++ b/Modules/Oracle_Module/k8sloadbalancer/variables.tf
@@ -1,13 +1,16 @@
 variable "compartment_ocid" {
-
+  description = "OCID of the compartment that owns the internal Kubernetes network load balancer."
+  type        = string
 }
 
 variable "subnet_id" {
-
+  description = "OCID of the private subnet the network load balancer is attached to."
+  type        = string
 }
 
 variable "oracleservers" {
-
+  description = "Map of OCI compute module instances; master nodes are registered as NLB backends on port 6443."
+  type        = any
 }
 
 locals {

--- a/Modules/Oracle_Module/network/network.tf
+++ b/Modules/Oracle_Module/network/network.tf
@@ -5,6 +5,10 @@ resource "oci_core_vcn" "vcn" {
   cidr_block     = var.vcn.cidr
   display_name   = var.vcn.name
   dns_label      = var.vcn.name
+  freeform_tags = {
+    Project   = "terraform-multicloud-infra"
+    ManagedBy = "Terraform"
+  }
 }
 
 #public subnet

--- a/Modules/Oracle_Module/network/outputs.tf
+++ b/Modules/Oracle_Module/network/outputs.tf
@@ -1,15 +1,19 @@
 output "ociprivatesubnet_id" {
-  value = oci_core_subnet.privatesubnet.id
+  description = "OCID of the private subnet that hosts the workload instances."
+  value       = oci_core_subnet.privatesubnet.id
 }
 
 output "ocipublicsubnet_id" {
-  value = oci_core_subnet.pubsubnet.id
+  description = "OCID of the first public subnet (AD3)."
+  value       = oci_core_subnet.pubsubnet.id
 }
 
 output "ocipublicsubnet2_id" {
-  value = oci_core_subnet.pubsubnet2.id
+  description = "OCID of the second public subnet (AD2), used by the public load balancer."
+  value       = oci_core_subnet.pubsubnet2.id
 }
 
 output "ocidrgid" {
-  value = oci_core_drg.drg.id
+  description = "OCID of the Dynamic Routing Gateway, consumed by the VPN module for the IPSec attachment."
+  value       = oci_core_drg.drg.id
 }

--- a/Modules/Oracle_Module/network/variables.tf
+++ b/Modules/Oracle_Module/network/variables.tf
@@ -1,5 +1,10 @@
 #Network variables
 variable "vcn" {
+  description = "Name and CIDR block for the OCI VCN."
+  type = object({
+    name = string
+    cidr = string
+  })
   default = {
     name = "vcn"
     cidr = "10.0.0.0/16"
@@ -7,6 +12,11 @@ variable "vcn" {
 }
 
 variable "internet_gateway" {
+  description = "Display name and default-route destination for the internet gateway."
+  type = object({
+    name           = string
+    destination_ip = string
+  })
   default = {
     name           = "igw"
     destination_ip = "0.0.0.0/0"
@@ -14,6 +24,11 @@ variable "internet_gateway" {
 }
 
 variable "nat_gateway" {
+  description = "Display name and default-route destination for the NAT gateway."
+  type = object({
+    name           = string
+    destination_ip = string
+  })
   default = {
     name           = "ngw"
     destination_ip = "0.0.0.0/0"
@@ -21,6 +36,11 @@ variable "nat_gateway" {
 }
 
 variable "privatesubnet" {
+  description = "Name and CIDR for the private subnet that hosts the workload instances."
+  type = object({
+    name = string
+    ip   = string
+  })
   default = {
     name = "privatesubnet",
     ip   = "10.0.1.0/24"
@@ -28,6 +48,11 @@ variable "privatesubnet" {
 }
 
 variable "pubsubnet" {
+  description = "Name and CIDR for the first public subnet (AD3)."
+  type = object({
+    name = string
+    ip   = string
+  })
   default = {
     name = "pubsubnet",
     ip   = "10.0.3.0/24"
@@ -35,6 +60,11 @@ variable "pubsubnet" {
 }
 
 variable "pubsubnet2" {
+  description = "Name and CIDR for the second public subnet (AD2), required for the public load balancer."
+  type = object({
+    name = string
+    ip   = string
+  })
   default = {
     name = "pubsubnet2",
     ip   = "10.0.5.0/24"
@@ -43,12 +73,23 @@ variable "pubsubnet2" {
 
 
 variable "egress_rules" {
+  description = "Protocol and destination CIDR for the security-list egress rule."
+  type = object({
+    protocol    = string
+    destination = string
+  })
   default = {
     protocol    = "all"
     destination = "0.0.0.0/0"
   }
 }
+
 variable "ingress_rules" {
+  description = "Protocol and source CIDR for the security-list ingress rule."
+  type = object({
+    protocol = string
+    source   = string
+  })
   default = {
     protocol = "all"
     source   = "0.0.0.0/0"
@@ -56,14 +97,22 @@ variable "ingress_rules" {
 }
 
 variable "compartment_id" {
+  description = "OCID of the compartment that owns the network resources."
+  type        = string
 }
 
 variable "AD" {
+  description = "Primary availability domain for subnets/instances."
+  type        = string
 }
 
 variable "AD2" {
+  description = "Second availability domain, used for the secondary public subnet."
+  type        = string
 }
 
 variable "azure_ipcidr" {
-  default = "192.0.0.0/16"
+  description = "Azure network CIDR routed over the DRG/VPN from the OCI route tables."
+  type        = string
+  default     = "192.0.0.0/16"
 }

--- a/Modules/Oracle_Module/publicloadbalancer/outputs.tf
+++ b/Modules/Oracle_Module/publicloadbalancer/outputs.tf
@@ -1,4 +1,4 @@
 output "public_ip" {
-  value = oci_load_balancer_load_balancer.public_load_balancer.ip_address_details[0].ip_address
+  description = "Public IP of the OCI load balancer fronting the worker NodePort (HTTPS 443)."
+  value       = oci_load_balancer_load_balancer.public_load_balancer.ip_address_details[0].ip_address
 }
-

--- a/Modules/Oracle_Module/publicloadbalancer/publiclb.tf
+++ b/Modules/Oracle_Module/publicloadbalancer/publiclb.tf
@@ -3,7 +3,7 @@ resource "oci_load_balancer_load_balancer" "public_load_balancer" {
   compartment_id = var.compartment_ocid
   display_name   = "publicloadbalancer"
   shape          = "flexible"
-  subnet_ids     = [var.subnet_id,var.subnet2_id]
+  subnet_ids     = [var.subnet_id, var.subnet2_id]
   #Optional
   is_private = false
   shape_details {
@@ -19,7 +19,7 @@ resource "oci_load_balancer_backend_set" "public_backend_set" {
     #Required
     protocol = "HTTP"
     #Optional
-    port = 31736
+    port     = 31736
     url_path = "/"
   }
   load_balancer_id = oci_load_balancer_load_balancer.public_load_balancer.id
@@ -28,17 +28,17 @@ resource "oci_load_balancer_backend_set" "public_backend_set" {
 }
 
 resource "oci_load_balancer_certificate" "certificate" {
-	#Required
-	certificate_name = "sslcertificate"
-	load_balancer_id = oci_load_balancer_load_balancer.public_load_balancer.id
+  #Required
+  certificate_name = "sslcertificate"
+  load_balancer_id = oci_load_balancer_load_balancer.public_load_balancer.id
 
-	#Optional
-	private_key = file("~/ssl/private.txt")
-	public_certificate = file("~/ssl/certificate.txt")
+  #Optional
+  private_key        = file("~/ssl/private.txt")
+  public_certificate = file("~/ssl/certificate.txt")
 
-	lifecycle {
-	    create_before_destroy = true
-	}
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "oci_load_balancer_listener" "public_listener" {
@@ -49,7 +49,7 @@ resource "oci_load_balancer_listener" "public_listener" {
   port                     = 443
   protocol                 = "HTTP"
   ssl_configuration {
-		certificate_name = oci_load_balancer_certificate.certificate.certificate_name
+    certificate_name        = oci_load_balancer_certificate.certificate.certificate_name
     verify_peer_certificate = false
   }
 }

--- a/Modules/Oracle_Module/publicloadbalancer/variables.tf
+++ b/Modules/Oracle_Module/publicloadbalancer/variables.tf
@@ -1,19 +1,23 @@
 variable "compartment_ocid" {
-
+  description = "OCID of the compartment that owns the public load balancer."
+  type        = string
 }
 
 variable "subnet_id" {
-
+  description = "OCID of the first public subnet the load balancer is attached to."
+  type        = string
 }
 
 variable "subnet2_id" {
-
+  description = "OCID of the second public subnet (different AD) the load balancer is attached to."
+  type        = string
 }
 
 variable "oracleservers" {
-
+  description = "Map of OCI compute module instances; worker nodes are registered as backends on the NodePort (31736)."
+  type        = any
 }
 
 locals {
-  instances = [for instance in var.oracleservers : instance.backenddetails if length(regexall("worker", instance.backenddetails.server_name)) > 0 ]
+  instances = [for instance in var.oracleservers : instance.backenddetails if length(regexall("worker", instance.backenddetails.server_name)) > 0]
 }

--- a/Modules/Vpn_Module/azure_vpn.tf
+++ b/Modules/Vpn_Module/azure_vpn.tf
@@ -11,7 +11,7 @@ resource "azurerm_public_ip" "azurevpngwpubip" {
   location            = var.azurelocation
   resource_group_name = var.azurergname
   allocation_method   = "Static"
-  sku = "Standard"
+  sku                 = "Standard"
 }
 
 data "azurerm_public_ip" "gwip" {

--- a/Modules/Vpn_Module/azure_vpn.tf
+++ b/Modules/Vpn_Module/azure_vpn.tf
@@ -29,7 +29,7 @@ resource "azurerm_virtual_network_gateway" "azurevpn" {
   vpn_type = "RouteBased"
 
   active_active = false
-  enable_bgp    = true
+  bgp_enabled   = true
   sku           = "VpnGw1"
 
   ip_configuration {
@@ -55,7 +55,7 @@ resource "azurerm_virtual_network_gateway_connection" "tooracle" {
 
   type                           = "IPsec"
   connection_protocol            = "IKEv2"
-  enable_bgp                     = true
+  bgp_enabled                    = true
   local_azure_ip_address_enabled = false
   virtual_network_gateway_id     = azurerm_virtual_network_gateway.azurevpn.id
   local_network_gateway_id       = azurerm_local_network_gateway.oraclecloud[each.value.index].id

--- a/Modules/Vpn_Module/oci_vpn.tf
+++ b/Modules/Vpn_Module/oci_vpn.tf
@@ -56,5 +56,6 @@ resource "null_resource" "ip_sec_connection_tunnel2_configuration" {
 
 
 output "drgid" {
-  value = var.drgid
+  description = "OCID of the DRG the IPSec connection is attached to (echoed for convenience)."
+  value       = var.drgid
 }

--- a/Modules/Vpn_Module/provider.tf
+++ b/Modules/Vpn_Module/provider.tf
@@ -9,5 +9,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.0.0"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0"
+    }
   }
 }

--- a/Modules/Vpn_Module/variables.tf
+++ b/Modules/Vpn_Module/variables.tf
@@ -1,28 +1,36 @@
 variable "oraclenetworkcidr" {
-  default = "10.0.0.0/16"
+  description = "OCI VCN CIDR advertised to Azure as the local network gateway address space."
+  type        = string
+  default     = "10.0.0.0/16"
 }
 
 variable "azuregatewaysubnetcidr" {
-  default = "192.0.0.0/24"
+  description = "CIDR for the Azure GatewaySubnet that hosts the Virtual Network Gateway."
+  type        = string
+  default     = "192.0.0.0/24"
 }
 
 variable "drgid" {
-
+  description = "OCID of the OCI Dynamic Routing Gateway the IPSec connection attaches to."
+  type        = string
 }
 
 variable "ocicompartment_id" {
-
+  description = "OCID of the compartment that owns the OCI CPE and IPSec connection."
+  type        = string
 }
 
 variable "azurelocation" {
-
+  description = "Azure region for the VPN gateway, public IP and connections."
+  type        = string
 }
 
 variable "azurergname" {
-
+  description = "Name of the Azure resource group hosting the VPN gateway resources."
+  type        = string
 }
 
 variable "azurevcnname" {
-
+  description = "Name of the Azure virtual network the GatewaySubnet is created in."
+  type        = string
 }
-

--- a/README.md
+++ b/README.md
@@ -1,58 +1,246 @@
-# Terraform Multicloud Infrastructure
+# Terraform Multi-Cloud Infrastructure
 
-This repository contains Terraform code to provision infrastructure across multiple clouds, including Azure and Oracle Cloud.
+Infrastructure-as-Code that provisions a single, VPN-meshed platform across **three
+public clouds** with Terraform. It stands up the compute, networking, load balancing
+and a site-to-site VPN needed to run a **highly-available Kubernetes cluster** and a
+**distributed MariaDB (Galera) database** that span Oracle Cloud and Azure, and it
+auto-generates the Ansible inventories used by the companion configuration repos.
+
+The codebase is organised as a small set of reusable, provider-scoped modules with a
+thin root configuration that wires them together and feeds them a declarative list of
+servers — so scaling the fleet up or down is a one-line edit.
+
+---
+
+## What it provisions
+
+| Cloud | Region | What gets created |
+|-------|--------|-------------------|
+| **Oracle Cloud (OCI)** | `us-phoenix-1` | VCN, public/private subnets across two ADs, IGW, NAT GW, DRG, security lists, **12 Ampere A1.Flex (ARM) instances**, a private **Network Load Balancer** for the Kubernetes API (`:6443`), and a public **Load Balancer** (`:443`) for ingress. |
+| **Azure** | `westus3` | Resource group, VNet, private subnet + NSG, **8 `Standard_D2ps_v5` (ARM) Spot VMs**, an internal **Standard Load Balancer** for the Kubernetes API (`:6443`), and a public **Application Gateway** (`:443`) for ingress. |
+| **AWS** | `us-east-1` | Remote-state backend (**S3** bucket + **DynamoDB** lock table) via `Backend_Module`, plus a standalone VPC/EC2 sample in `Aws_Module`. *(See "Remote backend bootstrap" — not wired into the active root by default.)* |
+| **VPN mesh** | OCI ↔ Azure | Site-to-site **IPSec** with **two BGP tunnels** (Azure `VpnGw1` ⇄ OCI DRG), so the two clouds share one routable private network. |
+
+The instance roles are derived from their hostnames (`*master*`, `*worker*`, `*db*`,
+`*bastion*`), which in turn drive load-balancer backend selection and Ansible inventory
+grouping.
+
+---
+
+## Architecture overview
+
+```
+                     ┌──────────────────────────────────────────────────┐
+                     │            Remote state (AWS, us-east-1)          │
+                     │   S3 bucket (versioned, AES256) + DynamoDB lock   │
+                     │                  table  [Backend_Module]          │
+                     └──────────────────────────────────────────────────┘
+                                         ▲  state + locking
+                                         │
+                ┌────────────────────────┴─────────────────────────┐
+                │                Terraform root config              │
+                │  providers.tf · servers.tf · *_resources.tf · vpn │
+                └───────────────┬───────────────────┬──────────────┘
+                                │                   │
+                                ▼                   ▼
+   ┌─────────────────────────────────┐  ┌─────────────────────────────────┐
+   │     Oracle Cloud — us-phoenix-1 │  │          Azure — westus3        │
+   │  VCN 10.0.0.0/16                │  │  VNet 192.0.0.0/16              │
+   │                                 │  │                                 │
+   │  private subnet                 │  │  private subnet                 │
+   │    12x A1.Flex ARM VM           │  │    8x D2ps_v5 ARM Spot VM       │
+   │    (master / worker / db)       │  │    (master / worker / db)       │
+   │  public subnets (AD2 + AD3)     │  │                                 │
+   │    argocd / jenkins / bastion   │  │  internal LB  :6443  (k8s API)  │
+   │                                 │  │  App Gateway  :443 ─► NodePort  │
+   │  NLB (private) :6443  k8s API   │  │                (PFX cert)       │
+   │  LB  (public)  :443 ─► NodePort │  │                                 │
+   │                 (SSL cert)      │  │  VPN Gateway (VpnGw1, BGP 65515)│
+   │  IGW · NAT · DRG  ◄───IPSec─────┼──┼───► VPN GW public IP            │
+   │       (BGP ASN 31898)           │  │     2x IKEv2 tunnel, BGP        │
+   └────────────────┬────────────────┘  └────────────────┬────────────────┘
+                    │ outputs: IPs, roles                 │ outputs: IPs, roles
+                    └──────────────────┬───────────────────┘
+                                       ▼
+                       ┌──────────────────────────────────┐
+                       │          Inventory_Module         │
+                       │  templatefile() → local_file →    │
+                       │  Ansible inventories (sibling repos)│
+                       └──────────────────────────────────┘
+
+   Advanced per-tunnel BGP/IPSec settings that the OCI Terraform provider does not
+   expose are applied by oci_vpn_advance_config/script.ts (OCI SDK) which the VPN
+   module invokes through a null_resource local-exec provisioner.
+```
+
+**Traffic / data flow.** The OCI VCN (`10.0.0.0/16`) and the Azure VNet
+(`192.0.0.0/16`) are joined by two BGP-routed IPSec tunnels, giving a flat private
+network across clouds. Kubernetes control-plane traffic hits the per-cloud internal
+load balancers on `:6443`; external ingress terminates TLS on each cloud's public load
+balancer (`:443`) and is forwarded to the worker NodePort (`31736`). The VPN exists so
+the MariaDB/Galera replicas stay in sync and so shared services (Jenkins, Argo CD, a
+bastion) can be reached from either side.
+
+---
+
+## Module breakdown
+
+```
+.
+├── providers.tf            # terraform block, provider aliases (aws/oci/azurerm), commented s3 backend
+├── backend.tf              # (commented) call into Backend_Module to bootstrap remote state
+├── variables.tf            # root inputs: ssh_key, oci_compartment_id, az_* creds, ssl_password
+├── servers.tf              # declarative server lists: locals.oracleservers (12) + var.azureservers (8)
+├── oracle_resources.tf     # wires the Oracle_Module sub-modules + outputs
+├── azure_resources.tf      # wires the Azure_Module sub-modules + outputs
+├── vpn.tf                  # wires the Vpn_Module (OCI ↔ Azure)
+├── dynamic_inventory.tf    # wires the Inventory_Module
+├── oci_vpn_advance_config/ # TypeScript helper for advanced OCI tunnel config (oci-sdk)
+└── Modules/
+    ├── Aws_Module/             # sample VPC + EC2 + EIP (standalone; not used by the active root)
+    ├── Backend_Module/         # S3 (versioned, AES256) + DynamoDB (PAY_PER_REQUEST) for remote state
+    ├── Inventory_Module/       # renders Ansible inventories via templatefile() + local_file
+    ├── Vpn_Module/             # OCI CPE/IPSec + Azure VPN GW + local/connection gateways (2 BGP tunnels)
+    ├── Oracle_Module/
+    │   ├── network/            # VCN, subnets, IGW, NAT, DRG, route tables, security lists
+    │   ├── compute/            # oci_core_instance (A1.Flex ARM) from a per-server input
+    │   ├── k8sloadbalancer/    # private Network Load Balancer, TCP :6443, masters as backends
+    │   └── publicloadbalancer/ # public Load Balancer, :443 ─► NodePort, workers as backends, SSL cert
+    └── Azure_Module/
+        ├── network/            # resource group, VNet, private subnet + NSG
+        ├── compute/            # azurerm_linux_virtual_machine (ARM Spot) + NIC + cloud-init
+        ├── k8sloadbalancer/    # internal Standard LB, TCP :6443, masters as backends
+        └── publicloadbalancer/ # Application Gateway, :443 ─► NodePort, workers as backends, PFX cert
+```
+
+The `Oracle_Module/compute` and `Azure_Module/compute` modules are instantiated with
+`for_each` over the server lists in `servers.tf`, and each emits a `server_details`
+output (name, role booleans, IPs) that the load-balancer and inventory modules consume.
+
+### The VPN helper (`oci_vpn_advance_config/`)
+The OCI Terraform provider cannot set per-tunnel BGP routing, custom IKE phase-1/phase-2
+parameters and DPD on an IPSec tunnel. `script.ts` fills that gap using the OCI Node SDK
+(`oci-core` / `oci-common`) and `updateIPSecConnectionTunnel`. The `Vpn_Module` compiles
+it (`tsc`) and runs it once per tunnel via `null_resource` `local-exec`, passing the
+IPSec/tunnel OCIDs and the BGP interface IPs as arguments. A failed update now exits
+non-zero so it surfaces as a Terraform error instead of being silently ignored.
+
+---
 
 ## Prerequisites
 
-- **Oracle and Azure Paid Accounts**: Necessary to set up their respective Terraform providers.
-- **Oracle Provider Setup**: Follow the instructions [here](https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/terraformproviderconfiguration.htm). This setup uses the SDK and CLI options.
-- **Azure Provider Setup**: Review the `variables.tf` file for variables starting with 'az_' and set their values in an environment file. Watch [this video](https://www.youtube.com/watch?v=wB52Rd5N9IQ&list=PLLc2nQDXYMHowSZ4Lkq2jnZ0gsJL3ArAw&index=5) for guidance.
-  - Ensure environment variables follow the format: `export TF_VAR_az_client_id="someclientid"`
-- **Compartment ID for Oracle**: In Oracle, create a new compartment beyond the default and export its ID to the environment (e.g., `export TF_VAR_oci_compartment_id="your_compartment_id"`).
-- **SSH Key Pair**: Create an SSH key pair for the servers and add its public key path to the `ssh_key` variable in `variables.tf` (or export it to the environment).
-- **SSL Certificate for Load Balancers**: Place your SSL certificate files in `~/ssl`, which should contain `ca.txt`, `certificate.txt`, `cert.pfx`, and `private.txt`. Export the `cert.pfx` SSL password to the environment, as needed by Azure's application gateway.
-- **Software Requirements**: Ensure Terraform CLI , Node.js and tsc are installed, the latter for advanced VPN configuration since it's unsupported by the OCI provider.
+- **Tooling:** Terraform CLI, plus **Node.js** and **TypeScript (`tsc`)** for the VPN
+  helper (required only when `vpn.tf` is enabled).
+- **OCI provider:** configured via the SDK/CLI config file or environment, per the
+  [OCI Terraform provider docs](https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/terraformproviderconfiguration.htm).
+  Provide the target compartment OCID:
+  ```bash
+  export TF_VAR_oci_compartment_id="ocid1.compartment.oc1..."
+  ```
+- **Azure provider:** a service principal exported as environment variables (these map
+  to the `az_*` variables and are marked `sensitive`):
+  ```bash
+  export TF_VAR_az_subscription_id="..."
+  export TF_VAR_az_client_id="..."
+  export TF_VAR_az_client_secret="..."
+  export TF_VAR_az_tenant_id="..."
+  ```
+- **AWS credentials:** only needed for the remote backend (S3 + DynamoDB in
+  `us-east-1`). Supply them via the standard AWS env vars, shared credentials file, or
+  an instance profile.
+- **SSH key:** a public key whose path is given to Terraform; it is injected into every
+  OCI and Azure instance:
+  ```bash
+  export TF_VAR_ssh_key="$HOME/.ssh/id_ed25519.pub"
+  ```
+- **TLS material for the public load balancers** in `~/ssl/` (paths are referenced
+  directly with `file()` / `filebase64()` in the code):
+  | File | Used by |
+  |------|---------|
+  | `~/ssl/private.txt` + `~/ssl/certificate.txt` | OCI public Load Balancer certificate |
+  | `~/ssl/cert.pfx` (PFX) | Azure Application Gateway listener |
 
-## Installation
+  The PFX password is supplied (also `sensitive`) as:
+  ```bash
+  export TF_VAR_ssl_password="..."
+  ```
 
-```bash
-git clone https://github.com/Moody-san/terraform-multicloud-infra.git
-cd terraform-multicloud-infra
-```
+---
+
+## Remote backend bootstrap (S3 + DynamoDB)
+
+State is stored remotely with S3 (versioned, server-side encrypted) and locked with
+DynamoDB. Because Terraform cannot store state in a bucket that does not yet exist, this
+is a two-phase, one-time bootstrap:
+
+1. **Create the backend resources with local state.** Uncomment the `module "backend"`
+   block in `backend.tf` (and set the `bucket_name` / `dynamodb_name`), then:
+   ```bash
+   terraform init
+   terraform apply -target=module.backend
+   ```
+2. **Switch to the remote backend.** Uncomment the `backend "s3" { ... }` block in
+   `providers.tf` so the `bucket`, `dynamodb_table`, `key` and `region` match what you
+   just created, then migrate the existing local state into S3:
+   ```bash
+   terraform init -migrate-state
+   ```
+
+From then on every `plan`/`apply` reads and locks state remotely. Bootstrapping the
+backend is optional — the configuration works with local state if you skip it.
+
+---
 
 ## Usage
 
 ```bash
+git clone https://github.com/Moody-san/terraform-multicloud-infra.git
+cd terraform-multicloud-infra
+
 terraform init
 terraform plan
 terraform apply
 ```
-## Configuration
 
-Edit the server.tf file to easily scale up and down on Oracle and Azure Cloud
+**Scaling the fleet** is done entirely in `servers.tf`: add or remove entries in
+`locals.oracleservers` (OCI) or `var.azureservers` (Azure). Each entry's `display_name` /
+`hostname` decides its role and therefore which load balancer pool and Ansible group it
+joins.
 
-## Optional Configuration
+### Optional toggles
+- **Skip a cloud / feature** by commenting the corresponding root file:
+  `azure_resources.tf` (Azure), `vpn.tf` (cross-cloud VPN), or `dynamic_inventory.tf`
+  (Ansible inventory generation).
+- **Regular vs Spot VMs (Azure):** comment the `priority` / `max_bid_price` /
+  `eviction_policy` lines in `Modules/Azure_Module/compute/compute.tf` to provision
+  on-demand instead of Spot VMs.
 
-- **Disable Azure Resources**: Comment out `azureresources.tf` and its references in `server.tf` if Azure is not needed.
-- **VM Instance Type**: To provision regular VMs instead of spot instances in Azure, comment the appropriate lines in the compute module file as indicated by the comments.
-- **VPN Setup**: Comment out `vpn.tf` if a VPN between the clouds is not required. Our use case for the VPN was to synchronize MariaDB and reuse Jenkins, Argo, and Bastion servers.
-- **Automated Inventory**: Comment out `inventory.tf` if not required . This uses inventory module to automatically setup inventory for ansible repositories mentioned in additional resources. 
+---
 
-## Additional Resources
+## Additional resources (companion repos)
 
-- **Kubernetes Setup**: For setting up Kubernetes on this infrastructure, see [ansible-k8s-deployment](https://github.com/Moody-san/ansible-k8s-deployment).
-- **MariaDB Cluster Setup**: For setting up a MariaDB cluster with Kubernetes-based failover, visit [ansible-galeracluster-deployment](https://github.com/Moody-san/ansible-galeracluster-deployment).
-- **CI/CD and Automation**: For CI/CD and other automation scripts, refer to [ansible-controller-setup](https://github.com/Moody-san/ansible-controller-setup).
-## Demo
+The `Inventory_Module` writes Ansible inventories straight into these sibling repos:
 
-https://www.youtube.com/watch?v=HC4oogjLf64
+- **Kubernetes setup:** [ansible-k8s-deployment](https://github.com/Moody-san/ansible-k8s-deployment)
+- **MariaDB/Galera cluster:** [ansible-galeracluster-deployment](https://github.com/Moody-san/ansible-galeracluster-deployment)
+- **CI/CD & controller automation:** [ansible-controller-setup](https://github.com/Moody-san/ansible-controller-setup)
 
-## Presentation
+## Demo & presentation
 
-https://docs.google.com/presentation/d/1peuU2K6cA1b9EeZd8g-iz_ve9KucFXQJLtqBe5yV294/edit?usp=sharing
+- Demo video: https://www.youtube.com/watch?v=HC4oogjLf64
+- Slides: https://docs.google.com/presentation/d/1peuU2K6cA1b9EeZd8g-iz_ve9KucFXQJLtqBe5yV294/edit?usp=sharing
 
-## Todo
+## Roadmap
 
-- Set up a jenkins controller that will watch terraform repository for infrastructure changes based on commits and update the deployed resources . Will have to use remote backend for state files for this .
-- Better more modular code with mockups for validating modules
-- Distributing the galera cluster across cloud kinda makes one cloud read only in case vpn is down , so instead either use an entirely different cloud for database or use 2 galera clusters (each on a different cloud) which remain in sync  .
+- A Jenkins controller that watches this repo and applies infrastructure changes on
+  commit (requires the remote backend above for shared state).
+- More modular code with mockups for validating modules in isolation.
+- Rethink the cross-cloud Galera topology: spreading one cluster across clouds makes a
+  cloud read-only if the VPN drops, so either dedicate a separate cloud to the database
+  or run two clusters (one per cloud) kept in sync.
+
+---
+
+> **Security note:** the demo security lists / NSGs are intentionally permissive
+> (allow-all) to keep the walkthrough simple. Tighten ingress/egress rules before any
+> non-demo use.

--- a/azure_resources.tf
+++ b/azure_resources.tf
@@ -39,7 +39,8 @@ module "k8sazurelb" {
 }
 
 output "azure_k8slb_private_ip" {
-  value = module.k8sazurelb.private_ip
+  description = "Private IP of the internal Azure load balancer fronting the Kubernetes API (port 6443)."
+  value       = module.k8sazurelb.private_ip
 }
 
 module "azurepubliclb" {
@@ -49,17 +50,19 @@ module "azurepubliclb" {
   }
   location     = module.azurenetwork.location
   rgname       = module.azurenetwork.name
-  vcnname =  module.azurenetwork.vcnname
+  vcnname      = module.azurenetwork.vcnname
   ssl_password = var.ssl_password
   azureservers = module.azureservers
   depends_on   = [module.azureservers]
 }
 
 output "azurepubliclb_publicip" {
-  value = module.azurepubliclb.public_ip
+  description = "Public IP of the Azure Application Gateway fronting the worker NodePort."
+  value       = module.azurepubliclb.public_ip
 }
 
 output "azure_servers" {
-  value = [for server in module.azureservers : server.output_ips]
+  description = "Name and IP of every provisioned Azure VM."
+  value       = [for server in module.azureservers : server.output_ips]
 }
 

--- a/oci_vpn_advance_config/package.json
+++ b/oci_vpn_advance_config/package.json
@@ -1,9 +1,10 @@
 {
   "name": "oci_vpn_advance_config",
   "version": "1.0.0",
-  "description": "",
+  "description": "Applies advanced per-tunnel IPSec/BGP settings to an OCI VPN connection that the OCI Terraform provider does not expose. Invoked by the Vpn_Module via null_resource local-exec.",
   "main": "script.js",
   "scripts": {
+    "build": "tsc script.ts",
     "script": "node script.js"
   },
   "author": "",

--- a/oci_vpn_advance_config/script.ts
+++ b/oci_vpn_advance_config/script.ts
@@ -11,8 +11,9 @@ const provider: common.ConfigFileAuthenticationDetailsProvider = new common.Conf
     const oracleIp = process.argv[4];    
     const customerIp = process.argv[5];
 
-    if (!ipsecId || !tunnelId ||!oracleIp ||!customerIp) {
+    if (!ipsecId || !tunnelId || !oracleIp || !customerIp) {
       console.error("Usage: node script.js <IPSec_ID> <Tunnel_ID> <oracleIp> <customerIp>");
+      process.exitCode = 1;
       return;
     }
     const updateIPSecConnectionTunnelDetails = {
@@ -57,7 +58,13 @@ const provider: common.ConfigFileAuthenticationDetailsProvider = new common.Conf
       updateIPSecConnectionTunnelRequest
     );
 
+    console.log(
+      `updateIPSecConnectionTunnel succeeded for tunnel ${tunnelId} (opc-request-id: ${updateIPSecConnectionTunnelResponse.opcRequestId})`
+    );
   } catch (error) {
-    console.log("updateIPSecConnectionTunnel Failed with error  " + error);
+    // Surface the failure to the caller (Terraform null_resource) via a non-zero exit code
+    // so a failed tunnel update aborts the apply instead of silently succeeding.
+    console.error("updateIPSecConnectionTunnel failed with error: " + error);
+    process.exitCode = 1;
   }
 })();

--- a/oracle_resources.tf
+++ b/oracle_resources.tf
@@ -9,7 +9,7 @@ module "oraclenetwork" {
   source         = "./Modules/Oracle_Module/network"
   compartment_id = var.oci_compartment_id
   AD             = data.oci_identity_availability_domains.ads.availability_domains[2]["name"]
-  AD2             = data.oci_identity_availability_domains.ads.availability_domains[1]["name"]
+  AD2            = data.oci_identity_availability_domains.ads.availability_domains[1]["name"]
 }
 
 module "oracleservers" {
@@ -32,7 +32,8 @@ module "oracleservers" {
 }
 
 output "oracle_servers" {
-  value = [for server in module.oracleservers : server.output_ips]
+  description = "Name and reachable IP of every provisioned OCI instance."
+  value       = [for server in module.oracleservers : server.output_ips]
 }
 
 
@@ -53,16 +54,18 @@ module "publicoracleloadbalancer" {
   }
   source           = "./Modules/Oracle_Module/publicloadbalancer"
   subnet_id        = module.oraclenetwork.ocipublicsubnet_id
-  subnet2_id        = module.oraclenetwork.ocipublicsubnet2_id
+  subnet2_id       = module.oraclenetwork.ocipublicsubnet2_id
   compartment_ocid = var.oci_compartment_id
   depends_on       = [module.oracleservers]
   oracleservers    = module.oracleservers
 }
 
 output "oracle_k8sprivatelb_ip" {
-  value = module.k8soracleloadbalancer.private_ip
+  description = "Private IP of the OCI network load balancer fronting the Kubernetes API (port 6443)."
+  value       = module.k8soracleloadbalancer.private_ip
 }
 
 output "oracle_publiclb_ip" {
-  value = module.publicoracleloadbalancer.public_ip
+  description = "Public IP of the OCI load balancer fronting the worker NodePort."
+  value       = module.publicoracleloadbalancer.public_ip
 }

--- a/servers.tf
+++ b/servers.tf
@@ -113,6 +113,15 @@ locals {
 
 
 variable "azureservers" {
+  description = "Declarative list of Azure VMs to provision (hostname drives the master/worker/db role and Ansible inventory grouping)."
+  type = list(object({
+    hostname  = string
+    diskgb    = number
+    disktype  = string
+    vm_size   = string
+    imagetype = string
+    imagename = string
+  }))
   default = [
     {
       hostname  = "azuremaster"

--- a/variables.tf
+++ b/variables.tf
@@ -1,27 +1,45 @@
-
 variable "ssh_key" {
-
+  description = "Path to the SSH public key file injected into every provisioned instance (OCI and Azure)."
+  type        = string
 }
+
 variable "oci_compartment_id" {
-
+  description = "OCID of the OCI compartment in which all Oracle Cloud resources are created."
+  type        = string
 }
+
 variable "oci_ubuntu22_id" {
-    default = "ocid1.image.oc1.phx.aaaaaaaa327eqiyphdvv4imkbpjcrhsf543cfmx3bttxzfu7tmae4kk7kqua"
+  description = "OCID of the Ubuntu 22.04 (ARM64) image used for all OCI compute instances."
+  type        = string
+  default     = "ocid1.image.oc1.phx.aaaaaaaa327eqiyphdvv4imkbpjcrhsf543cfmx3bttxzfu7tmae4kk7kqua"
 }
 
 variable "az_subscription_id" {
-
+  description = "Azure subscription ID for the service principal used by the azurerm provider."
+  type        = string
+  sensitive   = true
 }
+
 variable "az_client_id" {
-
+  description = "Azure service principal (application) client ID used by the azurerm provider."
+  type        = string
+  sensitive   = true
 }
+
 variable "az_client_secret" {
-
+  description = "Azure service principal client secret used by the azurerm provider."
+  type        = string
+  sensitive   = true
 }
-variable "az_tenant_id" {
 
+variable "az_tenant_id" {
+  description = "Azure Active Directory tenant ID for the service principal."
+  type        = string
+  sensitive   = true
 }
 
 variable "ssl_password" {
-  
+  description = "Password protecting the Azure Application Gateway PFX certificate (~/ssl/cert.pfx)."
+  type        = string
+  sensitive   = true
 }


### PR DESCRIPTION
Code-quality and maintainability pass across the whole module tree — formatting, variable typing/descriptions, provider pinning, deprecation fixes (S3 inline blocks split; `enable_bgp`→`bgp_enabled`), an `aws_eip vpc`→`domain` bug fix, output descriptions, tagging, a more robust TS VPN helper, and a rewritten README with an architecture overview. Verified: `terraform fmt -check -recursive` clean and `init -backend=false` + `validate` pass warning-free on the root and all 12 modules (no infra behavior changes; plan/apply not exercised, needs live cloud creds).